### PR TITLE
Correctly intercept "in" operator

### DIFF
--- a/src/main/groovy/org/kohsuke/groovy/sandbox/SandboxTransformer.groovy
+++ b/src/main/groovy/org/kohsuke/groovy/sandbox/SandboxTransformer.groovy
@@ -380,6 +380,19 @@ class SandboxTransformer extends CompilationCustomizer {
                 if (Ops.isLogicalOperator(exp.operation.type)) {
                     return super.transform(exp);
                 } else
+                if (exp.operation.type==Types.KEYWORD_IN) {// membership operator: JENKINS-28154
+                    // This requires inverted operand order:
+                    // "a in [...]" -> "[...].isCase(a)"
+                    if (interceptMethodCall)
+                        return makeCheckedCall("checkedCall", [
+                                transform(exp.rightExpression),
+                                boolExp(false),
+                                boolExp(false),
+                                stringExp("isCase"),
+                                transform(exp.leftExpression),
+
+                        ])
+                } else
                 if (Ops.isRegexpComparisonOperator(exp.operation.type)) {
                     if (interceptMethodCall)
                         return makeCheckedCall("checkedStaticCall", [

--- a/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
+++ b/src/test/groovy/org/kohsuke/groovy/sandbox/TheTest.groovy
@@ -705,4 +705,22 @@ Exception.message
         // x.nullProp shouldn't be intercepted, so the record should be empty
         assert cr.toString().trim()=="";
     }
+
+    void testInOperator() {
+        assertIntercept(
+            "Integer.isCase(Integer)", true, "1 in 1"
+        );
+
+        assertIntercept(
+            "Integer.isCase(Integer)", false, "1 in 2"
+        );
+
+        assertIntercept(
+            "ArrayList.isCase(Integer)", true, "1 in [1]"
+        );
+
+        assertIntercept(
+            "ArrayList.isCase(Integer)", false, "1 in [2]"
+        );
+    }
 }


### PR DESCRIPTION
[JENKINS-28154](https://issues.jenkins-ci.org/browse/JENKINS-28154)